### PR TITLE
Add instructions to install and build on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # Health-Barbecue
 
-## Pre-requirement
+## Requirements
 
 To launch the global application, you need:
-- docker [https://www.docker.com/](https://www.docker.com/)
-- docker-compose [https://docs.docker.com/compose/install/](https://docs.docker.com/compose/install/)
+- [Docker](https://www.docker.com/)
+- [Docker Compose](https://docs.docker.com/compose/install/)
 
-## Requirements on macOS
+### Requirements on macOS
+
+On macOS, you'll need specific steps to install Docker, Docker Compose, and the .NET Core SDK.
 
 For Docker, you'll need:
 
@@ -17,9 +19,10 @@ For Docker, you'll need:
 
 Setup:
 
-1. [optional] [Homebrew](https://brew.sh)
-2. Install Docker (e.g. with Homebrew: `brew cask install docker`)
-3. Run `open /Applications/Docker.app`
+1. [optional] Install [Homebrew](https://brew.sh) to get all the required tools easily.
+2. Install Docker and Docker Compose (e.g. with Homebrew: `brew cask install docker`).
+3. Install the [.NET Core SDK](https://dotnet.microsoft.com/download#macos) (e.g. with Homebrew: `brew cask install dotnet-sdk`).
+4. Run the command `open /Applications/Docker.app`.
 
 You can then proceed with the *Install* step below.
 
@@ -31,49 +34,60 @@ to Install all the stack, you should execute into the root folder the line below
 docker-compose -f "docker-compose.yml" up -d --build
 ```
 
-ps: If you have this kind of error “no matching manifest for windows/amd64 in the manifest list entries”, switch to Linux container in Docker Desktop.
+P.S. If you have the kind of error "no matching manifest for windows/amd64 in the manifest list entries", switch to **Linux container** in Docker Desktop.
+
 ## Usage
 
-### Orthanc server
+### Orthanc Server
 
-Once Orthanc is running, use Mozilla Firefox at URL [http://localhost:8042/](http://localhost:8042/) to interact with Orthanc. The default username is `barbecuehealth` and its password is `barbecuehealth`.
+Once Orthanc is running, use Mozilla Firefox at URL <http://localhost:8042/> to interact with Orthanc. The default username is `barbecuehealth` and its password is `barbecuehealth`.
 
-If you want to change login/password, edit file `config/orthanc.json` and add your new login into RegisteredUsers
+If you want to change the login/password, edit the file `config/orthanc.json` and add your new login into `RegisteredUsers`.
 
 ### Mongo Database
 
-A web Mongo client is available on the stack, you just need to use [http://localhost:8043/](http://localhost:8043/) to access MongoDB.
+A web Mongo client is available on the stack, you just need to use <http://localhost:8043/> to access MongoDB.
 
-### Web client
+### Web Client
 
-It is developed in React TypeScript and Yarn is using as package manager/cli
+It is developed in React TypeScript, and Yarn is used as the package manager/CLI.
 
 #### Docker
 
-It is available on [http://localhost:4000/](http://localhost:4000/)
+It is available on <http://localhost:4000/>.
 
 #### Locally
 
-you can run locally with the command:
+You can run locally with the command:
 
 ```bash
 cd ./client/web
 yarn && yarn start
 ```
 
-The application will be available on [http://localhost:3000](http://localhost:3000)
+The application will be available on <http://localhost:3000/>.
 
-## Devlopment
+## Development
 
 ### Business
 
 #### Requirement
+
+#### Build on macOS
+
+Run the command:
+
+```sh
+cd business/MetadataDatabase
+dotnet restore
+dotnet msbuild .
+```
 
 ### Web Client
 
 #### Requirement
 
 To develop, we need following tools:
- - NodeJs [https://nodejs.org/en/](https://nodejs.org/en/) >= 12
- - Yarn [https://classic.yarnpkg.com/lang/en/](https://classic.yarnpkg.com/lang/en/) ~1.20
 
+ - [Node.js](https://nodejs.org/en/) >= 12
+ - [Yarn](https://classic.yarnpkg.com/lang/en/) ~1.20

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ It is developed in React TypeScript, and Yarn is used as the package manager/CLI
 
 To develop, we need following tools:
 
- - [Node.js](https://nodejs.org/en/) >= 12
- - [Yarn](https://classic.yarnpkg.com/lang/en/) ~1.20
+- [Node.js](https://nodejs.org/en/) >= 12
+- [Yarn](https://classic.yarnpkg.com/lang/en/) ~1.20
 
 On macOS, you can install those tools with Homebrew by running the command `brew install yarn`.
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 ## Requirements
 
-To launch the global application, you need:
+Required to launch the global application:
 - [Docker](https://www.docker.com/)
 - [Docker Compose](https://docs.docker.com/compose/install/)
 
 ### Requirements on macOS
 
-On macOS, you'll need specific steps to install Docker, Docker Compose, and the .NET Core SDK.
+On macOS, specific steps are needed to install Docker, Docker Compose and the .NET Core SDK.
 
 For Docker, you'll need:
 
@@ -24,17 +24,17 @@ Setup:
 3. Install the [.NET Core SDK](https://dotnet.microsoft.com/download#macos) (e.g. with Homebrew: `brew cask install dotnet-sdk`).
 4. Run the command `open /Applications/Docker.app`.
 
-You can then proceed with the *Install* step below.
+Then, proceed with the Install step below.
 
 ## Install
 
-to Install all the stack, you should execute into the root folder the line below:
+to Install all the stack, the command below should be executed in the root folder:
 
 ```shell
 docker-compose -f "docker-compose.yml" up -d --build
 ```
 
-P.S. If you have the kind of error "no matching manifest for windows/amd64 in the manifest list entries", switch to **Linux container** in Docker Desktop.
+P.S. If the kind of error "no matching manifest for windows/amd64 in the manifest list entries" occurs, switch to **Linux container** in Docker Desktop.
 
 ## Usage
 
@@ -42,11 +42,11 @@ P.S. If you have the kind of error "no matching manifest for windows/amd64 in th
 
 Once Orthanc is running, use Mozilla Firefox at URL <http://localhost:8042/> to interact with Orthanc. The default username is `barbecuehealth` and its password is `barbecuehealth`.
 
-If you want to change the login/password, edit the file `config/orthanc.json` and add your new login into `RegisteredUsers`.
+To change the login/password, edit file `config/orthanc.json` and add a new login into `RegisteredUsers`.
 
 ### Mongo Database
 
-A web Mongo client is available on the stack, you just need to use <http://localhost:8043/> to access MongoDB.
+A web Mongo client being available on the stack, simply use <http://localhost:8043/> to access MongoDB.
 
 ### Web Client
 
@@ -54,12 +54,12 @@ It is developed in React TypeScript, and Yarn is used as the package manager/CLI
 
 #### Requirement
 
-To develop, we need following tools:
+The following tools are needed for development:
 
 - [Node.js](https://nodejs.org/en/) >= 12
 - [Yarn](https://classic.yarnpkg.com/lang/en/) ~1.20
 
-On macOS, you can install those tools with Homebrew by running the command `brew install yarn`.
+On macOS, these tools can be installed with Homebrew, by running the command `brew install yarn`.
 
 #### Docker
 
@@ -67,7 +67,7 @@ It is available on <http://localhost:4000/>.
 
 #### Locally
 
-You can run locally with the command:
+The web client can be ran locally with the commands:
 
 ```bash
 cd client/web
@@ -84,7 +84,7 @@ The application will be available on <http://localhost:3000/>.
 
 #### Build on macOS
 
-Run the command:
+Run the commands:
 
 ```sh
 cd business/MetadataDatabase

--- a/README.md
+++ b/README.md
@@ -52,6 +52,15 @@ A web Mongo client is available on the stack, you just need to use <http://local
 
 It is developed in React TypeScript, and Yarn is used as the package manager/CLI.
 
+#### Requirement
+
+To develop, we need following tools:
+
+ - [Node.js](https://nodejs.org/en/) >= 12
+ - [Yarn](https://classic.yarnpkg.com/lang/en/) ~1.20
+
+On macOS, you can install those tools with Homebrew by running the command `brew install yarn`.
+
 #### Docker
 
 It is available on <http://localhost:4000/>.
@@ -61,7 +70,7 @@ It is available on <http://localhost:4000/>.
 You can run locally with the command:
 
 ```bash
-cd ./client/web
+cd client/web
 yarn && yarn start
 ```
 
@@ -82,12 +91,3 @@ cd business/MetadataDatabase
 dotnet restore
 dotnet msbuild .
 ```
-
-### Web Client
-
-#### Requirement
-
-To develop, we need following tools:
-
- - [Node.js](https://nodejs.org/en/) >= 12
- - [Yarn](https://classic.yarnpkg.com/lang/en/) ~1.20


### PR DESCRIPTION
- Clean the Markdown format
- Add instructions to build the .NET business DLL on macOS
- Move up the instructions to install Node.js and Yarn for the web client since it would prevent us from running Yarn if not installed yet